### PR TITLE
Removed unique=True from UserOpenID.claimed_id

### DIFF
--- a/django_openid_auth/migrations/0001_initial.py
+++ b/django_openid_auth/migrations/0001_initial.py
@@ -43,7 +43,7 @@ class Migration(migrations.Migration):
             name='UserOpenID',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('claimed_id', models.TextField(unique=True, max_length=2047)),
+                ('claimed_id', models.TextField(max_length=2047)),
                 ('display_id', models.TextField(max_length=2047)),
                 ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
             ],

--- a/django_openid_auth/models.py
+++ b/django_openid_auth/models.py
@@ -57,7 +57,7 @@ class Association(models.Model):
 
 class UserOpenID(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL)
-    claimed_id = models.TextField(max_length=2047, unique=True)
+    claimed_id = models.TextField(max_length=2047)
     display_id = models.TextField(max_length=2047)
 
     class Meta:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ from setuptools import find_packages, setup
 
 
 description, long_description = __doc__.split('\n\n', 1)
-VERSION = '0.7'
+VERSION = '0.8'
 
 setup(
     name='django-openid-auth',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
     install_requires=[
         'django>=1.5',
         'python-openid>=2.2.0',
-        'south',
     ],
     package_data={
         'django_openid_auth': ['templates/openid/*.html'],


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-3664

django-openid-auth has claimed_id = TextField(unique=True). However, TextFields cannot be unique in MySQL: https://github.com/django/django/commit/e8cbc2b322d873a6fe39faca18d340ce93035087
https://docs.djangoproject.com/en/1.8/ref/models/fields/#textfield
https://code.djangoproject.com/ticket/2495

This results in the following error when running migrations:
"django.db.utils.OperationalError: (1170, "BLOB/TEXT column 'claimed_id' used in key specification without a key length")"
