### PR TITLE
Add on_delete argument for Django 2 compatibility

### DIFF
--- a/django_openid_auth/models.py
+++ b/django_openid_auth/models.py
@@ -56,7 +56,7 @@ class Association(models.Model):
 
 
 class UserOpenID(models.Model):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     claimed_id = models.TextField(max_length=2047)
     display_id = models.TextField(max_length=2047)
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ PY3 = sys.version_info.major >= 3
 
 
 description, long_description = __doc__.split('\n\n', 1)
-VERSION = '0.15.1'
+VERSION = '0.15.2'
 
 install_requires = ['django>=1.6', 'six']
 if PY3:


### PR DESCRIPTION
Django 2.0 added a mandatory on_delete argument, this patch deletes existing OpenID entries on user deletion as this was the default behavior previously.